### PR TITLE
fix(AtlasSDKClient): Allow instantiate AtlasSDKClient #107

### DIFF
--- a/src/api/atlas_sdk_client.js
+++ b/src/api/atlas_sdk_client.js
@@ -86,7 +86,7 @@ class AtlasSDKClient {
 
   /**
    * Creates an AtlasSDK instance from config provided by config-api
-   * @constructor {ignore}
+   * @constructor
    * @param {Object} config - config from config-api
    */
   constructor(config) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,3 +54,4 @@ const AtlasSDK = {
 };
 
 export default Object.assign({}, AtlasSDK, models);
+export { AtlasSDKClient };


### PR DESCRIPTION
Export AtlasSDKClient to let instantiate sdk using config object.

Closes #107