### PR TITLE
Remove zalando-incubator from orgs list

### DIFF
--- a/.zappr.yml
+++ b/.zappr.yml
@@ -5,7 +5,6 @@ approvals:
       from:
         orgs:
           - zalando
-          - zalando-incubator
 
 X-Zalando-Team: "dc"
 X-Zalando-Type: code


### PR DESCRIPTION
Remove unnecessary `zalando-incubator` org from zapper.